### PR TITLE
remove toString() added in beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/request-crypto",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Request Cryptography",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/request.ts
+++ b/src/request.ts
@@ -40,7 +40,6 @@ export async function createRequestDecryptor(privateJWKS: PrivateJWKS): Promise<
     async decrypt(encryptedBody: string) {
       const { encryptedAESKey, encryptedPayload } = unpackBody(encryptedBody);
       const encryptionKeyBuffer = await jwkManager.decrypt(encryptedAESKey);
-      console.log('encryptionKeyBuffer::', encryptionKeyBuffer.toString());
       const AES = makeAESCryptoWith({ encryptionKey: encryptionKeyBuffer });
       return AES.decrypt(encryptedPayload);
     },

--- a/src/request.ts
+++ b/src/request.ts
@@ -20,7 +20,7 @@ export async function createRequestEncryptor(publicJWKS: PublicJWKS): Promise<En
   return {
     async encrypt(kid, input) {
       const AESKeyBuffer = generatePassphrase();
-      const AES = makeAESCryptoWith({ encryptionKey: AESKeyBuffer.toString() });
+      const AES = makeAESCryptoWith({ encryptionKey: AESKeyBuffer });
       const encryptedPayload = await AES.encrypt(input);
       const encryptedKey = await jwkManager.encrypt(kid, AESKeyBuffer);
       return packBody(encryptedKey, encryptedPayload);
@@ -40,7 +40,8 @@ export async function createRequestDecryptor(privateJWKS: PrivateJWKS): Promise<
     async decrypt(encryptedBody: string) {
       const { encryptedAESKey, encryptedPayload } = unpackBody(encryptedBody);
       const encryptionKeyBuffer = await jwkManager.decrypt(encryptedAESKey);
-      const AES = makeAESCryptoWith({ encryptionKey: encryptionKeyBuffer.toString() });
+      console.log('encryptionKeyBuffer::', encryptionKeyBuffer.toString());
+      const AES = makeAESCryptoWith({ encryptionKey: encryptionKeyBuffer });
       return AES.decrypt(encryptedPayload);
     },
   };


### PR DESCRIPTION
`toString()` causes failure in decrypting payloads from previous releases. This means that we should keep using buffers as keys and changing it is a breaking change.

This change has not affected any products as it is under `request-crypto@beta`