### PR TITLE
Update node jose

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@elastic/node-crypto": "1.1.1",
-    "@types/node-jose": "1.1.0",
-    "node-jose": "1.1.0"
+    "@types/node-jose": "1.1.8",
+    "node-jose": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/request-crypto",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Request Cryptography",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Re-submitting #11.

Resolves #10.

This PR updates the `node-jose` dependency from version 1.1.0 to 2.0.0.
That removes support for Node 6 and Node 8, but I don't think we ever claimed / intended to support those.

* If we do want to support Node 6/8, we can upgrade to `node-jose` 1.1.4 instead to resolve the linked issue.
* If that is the case, we should explicitly mention somewhere what version(s) of Node that we support.