### PR TITLE
Upgrade GitHub Actions to use v6

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -18,9 +18,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'


### PR DESCRIPTION
It looks like CI is failing because of the old versions