### PR TITLE
Upgrade npm before releasing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@elastic'
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm publish
         env:


### PR DESCRIPTION
After testing the latest tag release: it seems it ran with npm version 10.9.8 which doesnt support OIDC Trusted Publishing.

This PR bumps the npm CLI version in the workflow which need version `11.5`+ to work