### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@elastic'
       - run: npm install -g npm@latest
       - run: npm install
       - run: npm publish


### PR DESCRIPTION
This PR attempts to resolve the error causing the failed publish workflow build. Removes `scope` from publish workflow.