### PR TITLE
[POC] - DO NOT MERGE - Replaces `node-jose` with native implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+## 3.0.0 (2026-08-04)
+
+### Summary
+
+Removes `node-jose` and replaces it with Node.js built-ins (`node:crypto` + `node:zlib`). The wire
+format is **unchanged** — tokens produced by 2.x and 3.x are byte-compatible in both directions,
+so no re-encryption or coordinated deploy is required.
+
+**Removes 15 transitive packages (~14.7 MB)** - leaves one runtime dependency:
+`@elastic/node-crypto`.
+
+Requires **Node.js ≥ 16**.
+
+---
+
+### Breaking changes
+
+#### The wire format does not change
+
+Byte-compatible in both directions with `node-jose`. No coordinated deploy, no re-encryption, and
+the encrypt and decrypt sides can be upgraded independently in either order.
+
+#### API changes (compile-time)
+
+| # | Change | Only reachable if… |
+|---|---|---|
+| 1 | `createJWKS(jwk, jwks?)` → `createJWKS(jwks?)` | you passed a node-jose `JWK` object as arg 1 |
+| 2 | `createJWKManager(jwks?, jwk?)` → `createJWKManager(jwks?, options?)` | you passed `jose.JWK` as arg 2 |
+| 3 | `new JWKSManager(store, jwk, jwe)` → `new JWKSManager(store, options?)` | same |
+| 4 | `JWKSManager.store: any` → `KeyStore` | you called node-jose keystore methods on `.store` |
+| 5 | `JWKMetadata` / `JWKDecryptResult` no longer alias `@types/node-jose` types | you relied on `@types/node-jose` resolving transitively through this package |
+
+Items 1–4 are only constructible by importing `node-jose` directly, which is the library being
+removed. Item 5 is structurally identical — the standalone interfaces have the same members in the
+same order.
+
+#### API changes (runtime)
+
+6. **`JWKDecryptResult.key.keystore` is removed.** It was a live node-jose back-reference to the
+   private keystore. It was already invisible to typed consumers (`JWKMetadata` excluded it), so
+   only untyped JavaScript could reach it. As a side effect, `getJWKMetadata().key` is now a flat
+   snapshot rather than a live key handle, so metadata can be logged without leaking key material.
+
+7. **A wrong-key / same-kid unwrap failure now throws `'decryption failed'`, not `'no key found'`.**
+   node-jose funnelled RSA unwrap failures into `no key found`; the replacement substitutes a random
+   CEK so the failure is indistinguishable from a MAC mismatch (RFC 3218 / RFC 7516 §11 defence).
+   The three cases that *are* asserted in practice — unknown kid, public-only store, unknown `alg`
+   — still produce `'no key found'` from the store lookup.
+
+8. **New 250 KB cap on inflated plaintext.** node-jose had no decompression limit. The request
+   encryption path has ~7,800× headroom (a 32-byte AES key inflated). If you encrypted large
+   buffers directly through `JWKSManager.encrypt()`, use the new `maxDecompressedSize` option:
+   ```js
+   await createRequestDecryptor(privateJWKS, { maxDecompressedSize: 500_000 });
+   ```
+
+9. **`removeKey` now works.** Previously a silent no-op (zero test coverage). It now removes all
+   entries matching the given `kid`.
+
+10. **`createJWKS(nonJWKS)` throws `TypeError`** instead of returning an empty store.
+
+11. **Unsupported `enc` values (e.g. `A256GCM`) throw** instead of silently decrypting.
+
+12. **`insertKey` with `form !== 'json'`** throws `'unsupported form: <form>'` instead of a
+    `SyntaxError`.
+
+13. **Integer-like `kid` values** retain insertion order in `toJSON` instead of node-jose's
+    accidental numeric-first reordering.
+
+#### Environment
+
+14. **`engines: { "node": ">=16" }` is new.** Node < 16 will not work — the required built-ins
+    (`crypto.createPublicKey({format:'jwk'})`, `Buffer 'base64url'`) were introduced in Node 15–16.
+
+---
+
+### New features
+
+- `KeyStore` and `StoredKey` are now exported from the package root (`src/keystore.ts`).
+- `JWKSManagerOptions.maxDecompressedSize` — configurable decompression limit, threaded through
+  all factory functions (`createRequestDecryptor`, `createJWKManager`, `createJWKSManager`).
+- `RSA_OAEP_256_ALGORITHM` (`'RSA-OAEP-256'`) exported from `src/jwks.ts` — keys tagged with
+  `alg: RSA-OAEP-256` now encrypt and decrypt correctly (previously they were silently
+  accepted but produced wrong output because node-jose derived the hash from the `alg` string,
+  which the replacement now also does).

--- a/README.md
+++ b/README.md
@@ -158,8 +158,57 @@ async function handler (event, context, callback) {
 
 If the key is not in the provided JWKS the function will throw an error `Error: no key found`.
 
+### Removing a key
+
+Pass the JWK object (must have a `kid` field) to `removeKey`. All keys with the matching `kid` are
+removed; unknown `kid` values are silently ignored.
+
+```js
+jwksManager.removeKey(jwksManager.getPublicJWK('kibana1'));
+```
+
+### Supported cryptographic profile
+
+| Parameter | Value |
+|---|---|
+| Key wrap algorithm (`alg`) | `RSA-OAEP` — RSAES-OAEP with SHA-1 and MGF1-SHA-1 |
+| Content encryption (`enc`) | `A128CBC-HS256` — AES-128-CBC + HMAC-SHA-256 |
+| Compression (`zip`) | `DEF` (raw DEFLATE per RFC 1951) or absent |
+| Serialization | JWE compact (5 Base64url segments) |
+
+Tokens produced by earlier versions (node-jose) and tokens produced by 3.x are byte-compatible in
+both directions. No re-encryption or coordinated upgrade is required.
+
+### Decompression limit (`maxDecompressedSize`)
+
+By default the decryptor rejects any token whose inflated plaintext exceeds **250,000 bytes**. This
+protects against decompression-bomb payloads (CVE-2024-28176 class). The request encryption path
+never produces plaintexts above a few kilobytes, so the default gives roughly 7,800× headroom.
+
+If you hold historical tokens whose plaintext exceeds the default — for example because an earlier
+version of the library encrypted a large buffer directly through `JWKSManager.encrypt()` — raise
+the limit at construction time:
+
+```js
+import { createRequestDecryptor } from '@elastic/request-crypto';
+
+const decryptor = await createRequestDecryptor(privateJWKS, {
+  maxDecompressedSize: 500_000,  // bytes; must be a positive finite number
+});
+```
+
+The same option is accepted by `createJWKManager`, `createJWKSManager`, and the `JWKSManager`
+constructor.
+
+### Requirements
+
+Node.js ≥ 16 (uses `crypto.createPublicKey({format:'jwk'})` introduced in Node 15.12 and
+`Buffer` `'base64url'` encoding introduced in Node 15.7 / 14.18).
+
 ### RFCs followed for implementation details
 
 - JWK RFC: https://tools.ietf.org/html/rfc7517
 - JWKS RFC: https://tools.ietf.org/html/rfc7517#appendix-A
+- JWE RFC: https://tools.ietf.org/html/rfc7516
+- JWA RFC: https://tools.ietf.org/html/rfc7518
 - PKCS RFC: https://tools.ietf.org/html/rfc3447

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/request-crypto",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "Request Cryptography",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -42,11 +42,9 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@elastic/node-crypto": "^1.2.3",
-    "@types/node-jose": "1.1.10",
-    "node-jose": "2.2.0"
+    "@elastic/node-crypto": "^1.2.3"
   },
-  "resolutions": {
-    "node-jose/uuid": "^11.1.1"
+  "engines": {
+    "node": ">=16"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export * from './jwks';
 export * from './jwk';
+export * from './jwks';
+export * from './keystore';
 export * from './random-bytes';
 export * from './request';

--- a/src/jwe.ts
+++ b/src/jwe.ts
@@ -1,0 +1,247 @@
+import * as crypto from 'crypto';
+import * as zlib from 'zlib';
+
+export const CONTENT_ALGORITHM = 'A128CBC-HS256'; // RFC 7518 §5.2.3
+export const ZIP_DEFLATE = 'DEF'; // RFC 7516 §4.1.3 — raw DEFLATE
+export const RSA_OAEP_256_ALGORITHM = 'RSA-OAEP-256';
+// DEFAULT only — overridable; CVE-2024-28176 class
+export const MAX_DECOMPRESSED_SIZE = 250000;
+
+export interface ParsedJWE {
+  // JSON.parse of segment 0, insertion order preserved
+  protectedHeader: Record<string, string>;
+  // Object.keys(protectedHeader) — not sorted, not filtered
+  protectedFields: string[];
+  // Buffer.from(segments[0], 'ascii') — the VERBATIM segment (RFC 7516 §5.2 step 14)
+  aad: Buffer;
+  encryptedKey: Buffer;
+  iv: Buffer;
+  ciphertext: Buffer;
+  tag: Buffer;
+}
+
+interface CipherParams {
+  cekBytes: number;
+  keyBytes: number; // cekBytes / 2
+  macAlgorithm: string;
+  cipherName: string;
+}
+
+// A128CBC-HS256 / A192CBC-HS384 / A256CBC-HS512 differ only in key split and digest.
+// Implements the family generically to insulate the decryptor from any historical enc variation.
+function cipherParamsFor(enc: string): CipherParams {
+  if (enc === 'A128CBC-HS256') {
+    return { cekBytes: 32, keyBytes: 16, macAlgorithm: 'sha256', cipherName: 'aes-128-cbc' };
+  }
+  if (enc === 'A192CBC-HS384') {
+    return { cekBytes: 48, keyBytes: 24, macAlgorithm: 'sha384', cipherName: 'aes-192-cbc' };
+  }
+  if (enc === 'A256CBC-HS512') {
+    return { cekBytes: 64, keyBytes: 32, macAlgorithm: 'sha512', cipherName: 'aes-256-cbc' };
+  }
+  throw new Error('unsupported "enc" algorithm: ' + enc);
+}
+
+// RFC 7518 §5.2.2.1: AL is the AAD bit length as a 64-bit big-endian integer.
+// Two 32-bit words, not one: writeUInt32BE(bits, 4) throws ERR_OUT_OF_RANGE past 512 MiB.
+// Arithmetic rather than >>> because tslint:recommended enables no-bitwise.
+function computeAL(aadByteLength: number): Buffer {
+  const al = Buffer.alloc(8);
+  const bits = aadByteLength * 8;
+  al.writeUInt32BE(Math.floor(bits / 4294967296), 0);
+  al.writeUInt32BE(bits % 4294967296, 4);
+  return al;
+}
+
+// RFC 7518 §5.2.2.1 steps 5-6: HMAC input = AAD ‖ IV ‖ ciphertext ‖ AL.
+// tagBytes = keyBytes (half the CEK), per RFC 7518 §5.2.2.1 step 9.
+function computeTag(
+  macKey: Buffer,
+  aad: Buffer,
+  iv: Buffer,
+  ciphertext: Buffer,
+  macAlgorithm: string,
+  tagBytes: number
+): Buffer {
+  return crypto
+    .createHmac(macAlgorithm, macKey)
+    .update(Buffer.concat([aad, iv, ciphertext, computeAL(aad.length)]))
+    .digest()
+    .subarray(0, tagBytes);
+}
+
+export function parseCompact(input: string | Buffer): ParsedJWE {
+  const compact = Buffer.isBuffer(input) ? input.toString('utf8') : input;
+  const segments = compact.split('.');
+  if (segments.length !== 5) {
+    throw new Error('invalid JWE: expected 5 segments, got ' + segments.length);
+  }
+  const headerB64 = segments[0];
+  let protectedHeader: Record<string, string>;
+  try {
+    const headerJSON = Buffer.from(headerB64, 'base64url').toString('utf8');
+    const obj = JSON.parse(headerJSON);
+    if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+      throw new Error('header must be a JSON object');
+    }
+    protectedHeader = obj;
+  } catch (e) {
+    throw new Error('invalid JWE: ' + e.message);
+  }
+  const iv = Buffer.from(segments[2], 'base64url');
+  const tag = Buffer.from(segments[4], 'base64url');
+  const ciphertext = Buffer.from(segments[3], 'base64url');
+  if (iv.length !== 16) {
+    throw new Error('invalid JWE: IV must be 16 bytes, got ' + iv.length);
+  }
+  if (tag.length !== 16) {
+    throw new Error('invalid JWE: tag must be 16 bytes, got ' + tag.length);
+  }
+  if (ciphertext.length === 0 || ciphertext.length % 16 !== 0) {
+    throw new Error(
+      'invalid JWE: ciphertext length must be a positive multiple of 16, got ' + ciphertext.length
+    );
+  }
+  return {
+    protectedHeader,
+    protectedFields: Object.keys(protectedHeader),
+    aad: Buffer.from(headerB64, 'ascii'),
+    encryptedKey: Buffer.from(segments[1], 'base64url'),
+    iv,
+    ciphertext,
+    tag,
+  };
+}
+
+// RSA-OAEP CEK unwrap with RFC 3218 / RFC 7516 §11 defence: a failed or wrong-length unwrap
+// yields a random CEK so the tag check in decryptContent fails identically. An unwrap failure
+// is therefore indistinguishable from a tag failure. Costs one randomBytes on failure only.
+export function unwrapKey(parsed: ParsedJWE, privateKey: crypto.KeyObject): Buffer {
+  const alg: string = parsed.protectedHeader.alg || '';
+  const enc: string = parsed.protectedHeader.enc || '';
+
+  // Determine CEK size from enc without throwing on unknown enc (avoids leaking error type).
+  let cekBytes = 32;
+  if (enc === 'A192CBC-HS384') {
+    cekBytes = 48;
+  } else if (enc === 'A256CBC-HS512') {
+    cekBytes = 64;
+  }
+
+  // oaepHash derived from alg per RFC 7518 §4.3.
+  // oaepHash satisfies the RsaPrivateKey union member of privateDecrypt's key parameter.
+  // Unknown alg falls through to random CEK so decryptContent's tag check fails identically.
+  let oaepHash: string;
+  if (alg === 'RSA-OAEP') {
+    oaepHash = 'sha1';
+  } else if (alg === RSA_OAEP_256_ALGORITHM) {
+    oaepHash = 'sha256';
+  } else {
+    return crypto.randomBytes(cekBytes);
+  }
+
+  try {
+    return crypto.privateDecrypt(
+      { key: privateKey, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash },
+      parsed.encryptedKey
+    );
+  } catch (e) {
+    return crypto.randomBytes(cekBytes);
+  }
+}
+
+// Decrypts a ParsedJWE's content with the given CEK.
+// maxDecompressedSize defaults to MAX_DECOMPRESSED_SIZE when omitted.
+export function decryptContent(
+  parsed: ParsedJWE,
+  cek: Buffer,
+  maxDecompressedSize?: number
+): Buffer {
+  const enc: string = parsed.protectedHeader.enc || '';
+  const params = cipherParamsFor(enc);
+  const macKey = cek.subarray(0, params.keyBytes);
+  const encKey = cek.subarray(params.keyBytes, params.cekBytes);
+
+  // RFC 7518 §5.2.2.2 — verify BEFORE decrypting (encrypt-then-MAC). This makes the CBC
+  // padding oracle unreachable: reaching decipher.final() implies a valid HMAC over these
+  // exact bytes, so no try/catch is needed there. Inflation happens last, on authenticated data.
+  // The length check is NOT decorative: timingSafeEqual THROWS on a length mismatch.
+  const expected = computeTag(
+    macKey,
+    parsed.aad,
+    parsed.iv,
+    parsed.ciphertext,
+    params.macAlgorithm,
+    params.keyBytes
+  );
+  if (parsed.tag.length !== expected.length || !crypto.timingSafeEqual(parsed.tag, expected)) {
+    throw new Error('decryption failed');
+  }
+
+  const decipher = crypto.createDecipheriv(params.cipherName, encKey, parsed.iv);
+  const plaintext = Buffer.concat([decipher.update(parsed.ciphertext), decipher.final()]);
+
+  // zip: protectedHeader.zip is Record<string,string> so type is string, but is absent (undefined)
+  // at runtime when the JWE header has no zip member. Comparison against ZIP_DEFLATE is safe.
+  const zip: string = parsed.protectedHeader.zip;
+  if (zip === ZIP_DEFLATE) {
+    const limit = maxDecompressedSize === undefined ? MAX_DECOMPRESSED_SIZE : maxDecompressedSize;
+    try {
+      return zlib.inflateRawSync(plaintext, { maxOutputLength: limit });
+    } catch (e) {
+      if (e && e.code === 'ERR_BUFFER_TOO_LARGE') {
+        throw new Error('decompressed payload exceeds limit of ' + limit + ' bytes');
+      }
+      throw e;
+    }
+  } else if (zip) {
+    throw new Error('unsupported "zip" algorithm: ' + zip);
+  }
+  return plaintext;
+}
+
+export function encryptCompact(
+  publicKey: crypto.KeyObject,
+  header: { zip?: string; enc: string; alg: string; kid?: string },
+  payload: Buffer
+): string {
+  const params = cipherParamsFor(header.enc);
+  const cek = crypto.randomBytes(params.cekBytes);
+  const macKey = cek.subarray(0, params.keyBytes);
+  const encKey = cek.subarray(params.keyBytes, params.cekBytes);
+
+  // Compress before encryption when zip is requested (per RFC 7516 §5.2 step 3).
+  let plaintext: Buffer = payload;
+  if (header.zip === ZIP_DEFLATE) {
+    plaintext = zlib.deflateRawSync(payload);
+  }
+
+  // Emit header in the given object's insertion order.
+  // object-literal-sort-keys: false is what permits {zip, enc, alg, kid} — alphabetizing
+  // silently changes the wire format and breaks interop with node-jose-produced tokens.
+  const headerJSON = JSON.stringify(header);
+  const headerB64 = Buffer.from(headerJSON, 'utf8').toString('base64url');
+  // AAD is the ASCII-encoded header segment (RFC 7516 §5.2 step 14).
+  // Never rebuild the header for AAD — use the segment verbatim so decrypt can reproduce it.
+  const aad = Buffer.from(headerB64, 'ascii');
+
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(params.cipherName, encKey, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = computeTag(macKey, aad, iv, ciphertext, params.macAlgorithm, params.keyBytes);
+
+  // oaepHash derived from alg per RFC 7518 §4.3; satisfies publicEncrypt's RsaPublicKey member.
+  const oaepHash = header.alg === RSA_OAEP_256_ALGORITHM ? 'sha256' : 'sha1';
+  const encryptedCek = crypto.publicEncrypt(
+    { key: publicKey, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash },
+    cek
+  );
+
+  return [
+    headerB64,
+    encryptedCek.toString('base64url'),
+    iv.toString('base64url'),
+    ciphertext.toString('base64url'),
+    tag.toString('base64url'),
+  ].join('.');
+}

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -1,5 +1,4 @@
-import * as jose from 'node-jose';
-import { createJWKS, JWKS, JWKSManager } from './jwks';
+import { createJWKS, JWKS, JWKSManager, JWKSManagerOptions } from './jwks';
 
 export const ENC_MODULUS = 2048;
 
@@ -9,7 +8,7 @@ export class JWKManager extends JWKSManager {
   }
 }
 
-export async function createJWKManager(jwks?: JWKS, jwk = jose.JWK) {
-  const store = await createJWKS(jwk, jwks);
-  return new JWKManager(store, jwk);
+export async function createJWKManager(jwks?: JWKS, options?: JWKSManagerOptions) {
+  const store = await createJWKS(jwks);
+  return new JWKManager(store, options);
 }

--- a/src/jwks.ts
+++ b/src/jwks.ts
@@ -1,4 +1,13 @@
-import * as jose from 'node-jose';
+import {
+  CONTENT_ALGORITHM,
+  decryptContent,
+  encryptCompact,
+  MAX_DECOMPRESSED_SIZE,
+  parseCompact,
+  unwrapKey,
+  ZIP_DEFLATE,
+} from './jwe';
+import { generateJWK, isJWKS, KeyStore, StoredKey } from './keystore';
 
 export interface JWKS<T = PublicJWK | PrivateJWK> {
   keys: T[];
@@ -34,7 +43,16 @@ export interface PrivateJWK extends PublicJWK {
   qi: string;
 }
 
-export type JWKMetadata = Pick<jose.JWK.Key, 'length' | 'kty' | 'kid' | 'use' | 'alg'>;
+// Reproduces @types/node-jose's JWK.KeyUse ('sig' | 'enc' | 'desc'), which is wider than
+// this package's KeyUse. Narrowing to KeyUse would make a consumer's `use === 'sig'` check
+// a TS2367 error; widening to string would break `const u: KeyUse = meta.use`.
+export interface JWKMetadata {
+  length: number;
+  kty: string;
+  kid: string;
+  use: KeyUse | 'sig';
+  alg: string;
+}
 
 export type KeyUse = 'enc' | 'desc';
 export type PublicJWKS = JWKS<PublicJWK>;
@@ -45,89 +63,155 @@ export type UnsignedJWK = PrivateJWK | PublicJWK;
 
 export const RSA_ALGORITHM = 'RSA-OAEP';
 
-export interface JWKDecryptResult extends Omit<jose.JWE.DecryptResult, 'key' | 'header'> {
-  /**
-   * JWK metadata
-   */
+export interface JWKDecryptResult {
   key: JWKMetadata;
   /**
    * an object of "protected" member key values.
    */
   header: Record<string, string>;
+  protected: string[];
+  plaintext: Buffer;
   /**
-   * payload Buffer
+   * payload Buffer — same Buffer object as plaintext (node-jose parity)
    */
   payload: Buffer;
 }
 
+export interface JWKSManagerOptions {
+  // Cap on inflated plaintext for zip: DEF tokens. Defaults to MAX_DECOMPRESSED_SIZE (250 KB).
+  // Raise it only if you hold historical tokens whose plaintext exceeds the default.
+  // Must be a positive finite number.
+  maxDecompressedSize?: number;
+}
+
 export class JWKSManager {
-  public store: any;
-  public JWK: typeof jose.JWK;
-  public JWE: typeof jose.JWE;
-  constructor(store: any, jwk = jose.JWK, jwe = jose.JWE) {
+  public store: KeyStore;
+  private maxDecompressedSize: number;
+
+  constructor(store: KeyStore, options: JWKSManagerOptions = {}) {
     this.store = store;
-    this.JWK = jwk;
-    this.JWE = jwe;
+    const specifiedSize = options.maxDecompressedSize;
+    if (specifiedSize !== undefined) {
+      if (!isFinite(specifiedSize) || specifiedSize <= 0) {
+        throw new Error('maxDecompressedSize must be a positive finite number');
+      }
+      this.maxDecompressedSize = specifiedSize;
+    } else {
+      this.maxDecompressedSize = MAX_DECOMPRESSED_SIZE;
+    }
   }
-  public async addKey(kid: string | undefined, modulus: number, use: KeyUse): Promise<void> {
-    const keyConfig = { alg: RSA_ALGORITHM, use, kid };
-    const privateKey = await this.JWK.createKey('RSA', modulus, keyConfig);
-    await this.insertKey(privateKey);
+
+  public async addKey(
+    kid: string | undefined,
+    modulus: number,
+    use: KeyUse,
+    alg?: string
+  ): Promise<void> {
+    const keyAlg = alg !== undefined ? alg : RSA_ALGORITHM;
+    const jwk = await generateJWK(modulus, { alg: keyAlg, use, kid });
+    await this.insertKey(jwk);
   }
-  public async insertKey(jwk: jose.JWK.Key): Promise<void> {
+
+  public async insertKey(jwk: JWK | Buffer | string): Promise<void> {
     await this.store.add(jwk);
   }
+
   public getPublicJWK(kid?: string): PublicJWK | null {
-    const jwk = this.getKey(kid);
-    if (!jwk) {
+    const key = this.getKey(kid);
+    if (!key) {
       return null;
     }
-    return jwk.toJSON();
+    return key.toJSON() as PublicJWK;
   }
+
   public getPrivateJWK(kid?: string): PrivateJWK | null {
-    const jwk = this.getKey(kid);
-    if (!jwk) {
+    const key = this.getKey(kid);
+    if (!key || !key.isPrivate) {
       return null;
     }
-    return jwk.toJSON(true);
+    return key.toJSON(true) as PrivateJWK;
   }
+
   public getPublicJWKS(): PublicJWKS {
-    return this.store.toJSON();
+    return this.store.toJSON() as PublicJWKS;
   }
+
   public getPrivateJWKS(): PrivateJWKS {
-    return this.store.toJSON(true);
+    return this.store.toJSON(true) as PrivateJWKS;
   }
+
   public removeKey(key: PublicJWK | PrivateJWK): void {
     return this.store.remove(key);
   }
+
   public async encrypt(kid: string, input: Buffer): Promise<string> {
-    const publicJWK = this.getKey(kid);
-    if (!publicJWK) {
+    const key = this.getKey(kid);
+    if (!key) {
       throw Error(`Missing kid (${kid}).`);
     }
-
-    return this.JWE.createEncrypt({ format: 'compact', zip: true }, publicJWK)
-      .update(input)
-      .final();
+    // Header alg comes from the KEY, not from RSA_ALGORITHM. Verified against node-jose 2.2.0:
+    // JWE.createEncrypt with no explicit alg emits the JWK's own alg member, falling back to
+    // 'RSA-OAEP' when absent. Hardcoding RSA_ALGORITHM here would silently downgrade a JWKS
+    // published as RSA-OAEP-256 and produce tokens its own receiver rejects with 'no key found'.
+    // object-literal-sort-keys: false is what permits {zip, enc, alg, kid} — do not alphabetize.
+    return encryptCompact(
+      key.publicKey,
+      { zip: ZIP_DEFLATE, enc: CONTENT_ALGORITHM, alg: key.alg || RSA_ALGORITHM, kid: key.kid },
+      input
+    );
   }
-  public async decrypt(payload: any, jwks = this.store): Promise<JWKDecryptResult> {
-    const decrypter = this.JWE.createDecrypt(jwks);
-    return (await decrypter.decrypt(payload)) as JWKDecryptResult;
+
+  public async decrypt(payload: any, jwks: KeyStore = this.store): Promise<JWKDecryptResult> {
+    const parsed = parseCompact(payload);
+    const header = parsed.protectedHeader;
+    // Filtering by alg reproduces node-jose's mechanism: an RSA1_5 header finds no candidate
+    // and yields 'no key found' rather than attempting a PKCS#1 v1.5 unwrap.
+    const key = jwks.get({ kid: header.kid, use: 'enc', alg: header.alg });
+    if (!key || !key.privateKey) {
+      throw new Error('no key found');
+    }
+    const cek = unwrapKey(parsed, key.privateKey);
+    const plaintext = decryptContent(parsed, cek, this.maxDecompressedSize);
+    return {
+      key: key.metadata(),
+      header,
+      protected: parsed.protectedFields,
+      plaintext,
+      // payload === plaintext — same Buffer object, node-jose parity
+      payload: plaintext,
+    };
   }
 
-  protected getKey(kid?: string): any {
+  protected getKey(kid?: string): StoredKey | null {
     return this.store.get(kid);
   }
 }
 
-export async function createJWKS(jwk: typeof jose.JWK, jwks?: JWKS): Promise<any> {
-  if (jwks) {
-    return jwk.asKeyStore(jwks);
+export async function createJWKS(jwks?: JWKS | string | Buffer): Promise<KeyStore> {
+  const store = new KeyStore();
+  if (jwks === undefined) {
+    return store;
   }
-  return jwk.createKeyStore();
+  let parsed: any;
+  if (typeof jwks === 'string' || Buffer.isBuffer(jwks)) {
+    try {
+      parsed = JSON.parse(typeof jwks === 'string' ? jwks : (jwks as Buffer).toString('utf8'));
+    } catch (e) {
+      throw new TypeError('invalid JWKS: ' + e.message);
+    }
+  } else {
+    parsed = jwks;
+  }
+  if (!isJWKS(parsed)) {
+    throw new TypeError('expected a JWKS ({ keys: [...] }), got ' + typeof parsed);
+  }
+  for (const k of parsed.keys) {
+    await store.add(k);
+  }
+  return store;
 }
 
-export async function createJWKSManager(jwks?: JWKS) {
-  const store = await createJWKS(jose.JWK, jwks);
-  return new JWKSManager(store, jose.JWK);
+export async function createJWKSManager(jwks?: JWKS, options?: JWKSManagerOptions) {
+  const store = await createJWKS(jwks);
+  return new JWKSManager(store, options);
 }

--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -1,0 +1,280 @@
+import * as crypto from 'crypto';
+import {
+  JWK,
+  JWKMetadata,
+  JWKS,
+  KeyUse,
+  PrivateJWK,
+  PrivateJWKS,
+  PublicJWK,
+  PublicJWKS,
+} from './jwks';
+
+export interface KeyFilter {
+  kid?: string;
+  kty?: string;
+  use?: string;
+  alg?: string;
+}
+
+export interface StoredKey {
+  kty: string;
+  kid: string;
+  use: string; // '' when absent — node-jose parity
+  alg: string; // '' when absent
+  length: number; // RSA modulus size in bits
+  isPrivate: boolean;
+  publicKey: crypto.KeyObject;
+  privateKey: crypto.KeyObject | null;
+  toJSON(isPrivate?: boolean): PublicJWK | PrivateJWK;
+  metadata(): JWKMetadata;
+}
+
+// node-jose filter semantics: skip each attribute check when either the filter value
+// or the key's own value is falsy. The falsy-skip on kid is what makes a no-kid token
+// resolve against the first key in the store.
+function matchesFilter(key: StoredKey, filter: KeyFilter): boolean {
+  if (filter.kid && key.kid && filter.kid !== key.kid) {
+    return false;
+  }
+  if (filter.use && key.use && filter.use !== key.use) {
+    return false;
+  }
+  if (filter.alg && key.alg && filter.alg !== key.alg) {
+    return false;
+  }
+  if (filter.kty && key.kty && filter.kty !== key.kty) {
+    return false;
+  }
+  return true;
+}
+
+export class KeyStore {
+  // Array, not Map — target: ES5 with no downlevelIteration; insertion order preserved.
+  private keys: StoredKey[];
+
+  constructor() {
+    this.keys = [];
+  }
+
+  // Accepts JWK | Buffer | string; a StoredKey is deep-copied via toJSON(true).
+  // Stays async so store.add(x).then(...) keeps working and throws surface as rejections.
+  public async add(input: JWK | Buffer | string, form?: string): Promise<StoredKey> {
+    const key = importKey(input, form);
+    this.keys.push(key);
+    return key;
+  }
+
+  // get() with no argument returns the first key.
+  // get(string) filters by kid. get(KeyFilter) uses the node-jose filter semantics above.
+  public get(kidOrFilter?: string | KeyFilter): StoredKey | null {
+    if (kidOrFilter === undefined) {
+      return this.keys.length > 0 ? this.keys[0] : null;
+    }
+    if (typeof kidOrFilter === 'string') {
+      return this.all({ kid: kidOrFilter })[0] || null;
+    }
+    return this.all(kidOrFilter)[0] || null;
+  }
+
+  public all(filter?: KeyFilter): StoredKey[] {
+    if (filter === undefined) {
+      return this.keys.slice();
+    }
+    return this.keys.filter(k => matchesFilter(k, filter));
+  }
+
+  // remove — the bug fix: actually removes entries with the matching kid.
+  // Silent no-op for unknown / undefined / null input. Removes ALL entries with that kid.
+  public remove(input?: JWK | StoredKey | string | null): void {
+    if (!input) {
+      return;
+    }
+    const kid = typeof input === 'string' ? input : input.kid;
+    if (!kid) {
+      return;
+    }
+    this.keys = this.keys.filter(k => k.kid !== kid);
+  }
+
+  public toJSON(isPrivate?: boolean): PublicJWKS | PrivateJWKS {
+    return {
+      keys: this.keys.map(k => k.toJSON(isPrivate)),
+    };
+  }
+}
+
+// RFC 7638 JWK Thumbprint for RSA keys: sha256(JSON.stringify({e,kty,n})) in base64url.
+// Members must be in lexicographic order: e, kty, n.
+export function jwkThumbprint(jwk: { kty: string; n: string; e: string }): string {
+  const canonical = JSON.stringify({ e: jwk.e, kty: jwk.kty, n: jwk.n });
+  return crypto
+    .createHash('sha256')
+    .update(canonical)
+    .digest()
+    .toString('base64url');
+}
+
+export function isJWKS(input: any): input is JWKS {
+  return (
+    input !== null &&
+    typeof input === 'object' &&
+    !Array.isArray(input) &&
+    Array.isArray(input.keys)
+  );
+}
+
+// Imports a JWK (or JSON Buffer/string) into a StoredKey.
+// Throws synchronously on invalid input. Called by KeyStore.add via async wrapper.
+export function importKey(input: JWK | Buffer | string, form?: string): StoredKey {
+  if (form !== undefined && form !== 'json') {
+    throw new Error('unsupported form: ' + form);
+  }
+
+  let raw: any;
+  if (Buffer.isBuffer(input)) {
+    raw = JSON.parse(input.toString('utf8'));
+  } else if (typeof input === 'string') {
+    raw = JSON.parse(input);
+  } else {
+    // Plain object: copy so we never retain the caller's reference.
+    raw = Object.assign({}, input);
+  }
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw) || raw.kty !== 'RSA') {
+    throw new Error('unsupported key type');
+  }
+
+  const pjwk: PrivateJWK = raw as PrivateJWK;
+  const pub: PublicJWK = raw as PublicJWK;
+  const isPrivate = typeof pjwk.d === 'string' && pjwk.d.length > 0;
+
+  // Build fresh object literals to satisfy crypto.JsonWebKey's index signature;
+  // this also strips kid/use/alg so Node does not try to interpret them.
+  const publicJwkRaw = { kty: pub.kty, n: pub.n, e: pub.e };
+  const publicKey = crypto.createPublicKey({ key: publicJwkRaw, format: 'jwk' });
+
+  let privateKey: crypto.KeyObject | null = null;
+  if (isPrivate) {
+    const privateJwkRaw = {
+      kty: pjwk.kty,
+      n: pjwk.n,
+      e: pjwk.e,
+      d: pjwk.d,
+      p: pjwk.p,
+      q: pjwk.q,
+      dp: pjwk.dp,
+      dq: pjwk.dq,
+      qi: pjwk.qi,
+    };
+    privateKey = crypto.createPrivateKey({ key: privateJwkRaw, format: 'jwk' });
+  }
+
+  // asymmetricKeyDetails is optional at both levels (strictNullChecks guard required).
+  const details = publicKey.asymmetricKeyDetails;
+  const length =
+    details !== undefined && details.modulusLength !== undefined ? details.modulusLength : 0;
+
+  const rawKid: string = pub.kid || '';
+  const kid = rawKid.length > 0 ? rawKid : jwkThumbprint(pub);
+  const use: string = pub.use || '';
+  const alg: string = pub.alg || '';
+
+  // Precompute exported JWK — byte-identical round-trip for n/e/d/p/q/dp/dq/qi.
+  // Return Object.assign({}, cached) per call so callers cannot mutate the store.
+  const exportedPub = publicKey.export({ format: 'jwk' });
+  const exportedPriv: crypto.JsonWebKey | null =
+    isPrivate && privateKey !== null
+      ? (privateKey as crypto.KeyObject).export({ format: 'jwk' })
+      : null;
+
+  function makePublicJSON(): PublicJWK {
+    const result: any = { kty: 'RSA', kid };
+    if (use) {
+      result.use = use;
+    }
+    if (alg) {
+      result.alg = alg;
+    }
+    result.e = exportedPub.e as string;
+    result.n = exportedPub.n as string;
+    return result as PublicJWK;
+  }
+
+  function toJSON(includePrivate?: boolean): PublicJWK | PrivateJWK {
+    if (includePrivate && isPrivate && exportedPriv !== null) {
+      const result: any = { kty: 'RSA', kid };
+      if (use) {
+        result.use = use;
+      }
+      if (alg) {
+        result.alg = alg;
+      }
+      result.e = exportedPub.e as string;
+      result.n = exportedPub.n as string;
+      result.d = exportedPriv.d as string;
+      result.p = exportedPriv.p as string;
+      result.q = exportedPriv.q as string;
+      result.dp = exportedPriv.dp as string;
+      result.dq = exportedPriv.dq as string;
+      result.qi = exportedPriv.qi as string;
+      return result as PrivateJWK;
+    }
+    return makePublicJSON();
+  }
+
+  const storedKey: StoredKey = {
+    kty: 'RSA',
+    kid,
+    use,
+    alg,
+    length,
+    isPrivate,
+    publicKey,
+    privateKey,
+    toJSON,
+    metadata(): JWKMetadata {
+      return { length, kty: 'RSA', kid, use: use as KeyUse | 'sig', alg };
+    },
+  };
+  return storedKey;
+}
+
+// Generates a new RSA key pair and returns the result as a PrivateJWK.
+// Wrapped in a Promise directly to avoid util.promisify's overload complexity.
+export function generateJWK(
+  modulusLength: number,
+  config: { alg: string; use: KeyUse; kid?: string }
+): Promise<PrivateJWK> {
+  return new Promise((resolve, reject) => {
+    crypto.generateKeyPair(
+      'rsa',
+      { modulusLength, publicExponent: 0x10001 },
+      (err, publicKey, privateKey) => {
+        if (err) {
+          return reject(err);
+        }
+        const exportedPub = publicKey.export({ format: 'jwk' });
+        const exportedPriv = privateKey.export({ format: 'jwk' });
+        const configKid: string = config.kid || '';
+        const kid = configKid.length > 0 ? configKid : crypto.randomUUID();
+        // Assemble in node-jose's member order: kty, kid, use, alg, e, n, d, p, q, dp, dq, qi
+        const jwk: PrivateJWK = {
+          kty: 'RSA',
+          kid,
+          use: config.use,
+          alg: config.alg,
+          e: exportedPub.e as string,
+          n: exportedPub.n as string,
+          d: exportedPriv.d as string,
+          p: exportedPriv.p as string,
+          q: exportedPriv.q as string,
+          dp: exportedPriv.dp as string,
+          dq: exportedPriv.dq as string,
+          qi: exportedPriv.qi as string,
+        };
+        resolve(jwk);
+      }
+    );
+  });
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,8 +1,7 @@
 import makeAESCryptoWith, { EncryptOutput } from '@elastic/node-crypto';
-import { util } from 'node-jose';
 
 import { createJWKManager } from './jwk';
-import { JWKDecryptResult, PrivateJWKS, PublicJWK, PublicJWKS } from './jwks';
+import { JWKDecryptResult, JWKSManagerOptions, PrivateJWKS, PublicJWK, PublicJWKS } from './jwks';
 import { generatePassphrase } from './random-bytes';
 
 export interface Encryptor {
@@ -31,8 +30,11 @@ export async function createRequestEncryptor(publicJWKS: PublicJWKS): Promise<En
   };
 }
 
-export async function createRequestDecryptor(privateJWKS: PrivateJWKS): Promise<Decryptor> {
-  const jwkManager = await createJWKManager(privateJWKS);
+export async function createRequestDecryptor(
+  privateJWKS: PrivateJWKS,
+  options?: JWKSManagerOptions
+): Promise<Decryptor> {
+  const jwkManager = await createJWKManager(privateJWKS, options);
   return {
     getPublicComponent(kid: string) {
       return jwkManager.getPublicJWK(kid);
@@ -59,11 +61,11 @@ export function packBody(encryptedAESKey: string, encryptedPayload: string): str
     encryptedAESKey,
     encryptedPayload,
   });
-  return util.base64url.encode(packedBodyStringifiedJSON, 'utf8');
+  return Buffer.from(packedBodyStringifiedJSON, 'utf8').toString('base64url');
 }
 
 export function unpackBody(packedBody: string) {
-  const decodedBody = (util.base64url.decode(packedBody) as unknown) as Buffer;
+  const decodedBody = Buffer.from(packedBody, 'base64url');
   const { encryptedAESKey, encryptedPayload } = JSON.parse(decodedBody.toString('utf8'));
   return { encryptedAESKey, encryptedPayload };
 }

--- a/test/compat.spec.ts
+++ b/test/compat.spec.ts
@@ -1,0 +1,130 @@
+import { CONTENT_ALGORITHM, encryptCompact, ZIP_DEFLATE } from '../src/jwe';
+import { createJWKSManager, RSA_ALGORITHM } from '../src/jwks';
+import { createRequestDecryptor, packBody, unpackBody } from '../src/request';
+
+import { encryptedRequest } from './fixture/encrypted_jwk';
+import {
+  noZipPlaintext,
+  noZipToken,
+  packedBody,
+  packedBodySentinel,
+  packedBodySentinelAESKey,
+  packedBodySentinelPayload,
+  zipKeyMeta,
+  zipPlaintext,
+  zipToken,
+} from './fixture/node_jose_vectors';
+import { privateJWKS } from './fixture/private_jwks';
+
+describe('node-jose compatibility', () => {
+  describe('decrypt node-jose zip token', () => {
+    it('decrypts zip token to correct plaintext', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(zipToken);
+      expect(result.plaintext.toString('utf8')).to.equal(zipPlaintext);
+    });
+
+    it('protected fields are in node-jose insertion order', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(zipToken);
+      expect(result.protected).to.eql(['zip', 'enc', 'alg', 'kid']);
+    });
+
+    it('payload === plaintext (same Buffer object)', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(zipToken);
+      expect(result.payload).to.equal(result.plaintext);
+    });
+
+    it('key metadata matches node-jose shape (no keystore back-ref)', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(zipToken);
+      expect(result.key).to.eql(zipKeyMeta);
+      expect(Object.keys(result.key)).to.eql(['length', 'kty', 'kid', 'use', 'alg']);
+    });
+  });
+
+  describe('decrypt node-jose no-zip token', () => {
+    it('decrypts no-zip token to correct plaintext', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(noZipToken);
+      expect(result.plaintext.toString('utf8')).to.equal(noZipPlaintext);
+    });
+
+    it('protected fields exclude zip when absent', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const result = await manager.decrypt(noZipToken);
+      expect(result.protected).to.eql(['enc', 'alg', 'kid']);
+    });
+  });
+
+  describe('packBody / unpackBody compat with node-jose util.base64url', () => {
+    it('packBody sentinel matches node-jose util.base64url.encode byte-for-byte', () => {
+      const result = packBody(packedBodySentinelAESKey, packedBodySentinelPayload);
+      expect(result).to.equal(packedBodySentinel);
+    });
+
+    it('unpackBody round-trips packBody', () => {
+      const packed = packBody('key-value', 'payload-value');
+      const { encryptedAESKey, encryptedPayload } = unpackBody(packed);
+      expect(encryptedAESKey).to.equal('key-value');
+      expect(encryptedPayload).to.equal('payload-value');
+    });
+
+    it('unpackBody handles multi-byte UTF-8', () => {
+      const key = 'key-é-中文';
+      const payload = 'payload-é-中文';
+      const packed = packBody(key, payload);
+      const { encryptedAESKey, encryptedPayload } = unpackBody(packed);
+      expect(encryptedAESKey).to.equal(key);
+      expect(encryptedPayload).to.equal(payload);
+    });
+  });
+
+  describe('createRequestDecryptor decrypts node-jose packed body', () => {
+    it('decrypts frozen packedBody end-to-end', async () => {
+      const decryptor = await createRequestDecryptor(privateJWKS);
+      const result = await decryptor.decrypt(packedBody);
+      expect(result).to.be.an('object');
+      expect((result as any).test).to.equal('packed-body-compat');
+      expect((result as any).source).to.equal('node-jose');
+    });
+  });
+
+  describe('our own encrypt output has node-jose header member order', () => {
+    it('header members are in zip,enc,alg,kid order', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const token = await manager.encrypt('KIBANA', Buffer.from('hello', 'utf8'));
+      const headerB64 = token.split('.')[0];
+      const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8'));
+      expect(Object.keys(header)).to.eql(['zip', 'enc', 'alg', 'kid']);
+    });
+  });
+
+  describe('frozen KIBANA_7.0 token parses without its private key', () => {
+    it('yields no key found on decrypt attempt', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      let errorMessage = '';
+      try {
+        await manager.decrypt(encryptedRequest.encryptedKey);
+      } catch (err) {
+        errorMessage = err.toString();
+      }
+      expect(errorMessage).to.equal('Error: no key found');
+    });
+  });
+
+  describe('no-kid token resolves against first key', () => {
+    it('decrypts when token has no kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const key = manager.store.get('KIBANA');
+      const token = encryptCompact(
+        key.publicKey,
+        { zip: ZIP_DEFLATE, enc: CONTENT_ALGORITHM, alg: RSA_ALGORITHM },
+        Buffer.from('hello no-kid', 'utf8')
+      );
+      const result = await manager.decrypt(token);
+      expect(result.plaintext.toString('utf8')).to.equal('hello no-kid');
+    });
+  });
+});

--- a/test/fixture/node_jose_vectors.ts
+++ b/test/fixture/node_jose_vectors.ts
@@ -1,0 +1,84 @@
+/**
+ * Frozen test vectors generated from node-jose@2.2.0.
+ *
+ * Generated: 2026-07-31
+ * Generator: test/../scratchpad/node-jose-vectors/generate.js
+ * node-jose: 2.2.0  @elastic/node-crypto: 1.2.3
+ * Key: 1024-bit KIBANA fixture (test/fixture/private_jwks.ts)
+ *
+ * NEVER regenerate this file without also re-running the reverse interop check.
+ * The generator script asserts:
+ *   - node-jose decrypts its own zipToken and noZipToken correctly
+ *   - node:crypto + zlib built-in token is decryptable by node-jose with
+ *     protected == ['zip','enc','alg','kid'] and payload === plaintext
+ */
+
+// Plaintext that was encrypted to produce zipToken.
+// protected: ['zip', 'enc', 'alg', 'kid']
+export const zipPlaintext = '{"test":"node-jose-compat","zip":true,"kid":"KIBANA"}';
+
+// node-jose compact JWE with zip: DEF (zip: true).
+// Header (decoded): { zip: 'DEF', enc: 'A128CBC-HS256', alg: 'RSA-OAEP', kid: 'KIBANA' }
+export const zipToken =
+  'eyJ6aXAiOiJERUYiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJLSUJBTkEifQ' +
+  '.RUYluzht77t0DRHQazgn2l_90Cdy6lqCGSc3XgMc-5ImvpJaGNmKxjBO-5rsChWnvY1FIqkuYsRM5gRua0P2SCl' +
+  'RLAql_S-PL3p5ieueD2Vql0RFSHVksQAM5WvBuaYgP31A9RCneLWukBl7L_dBzUYXhzDQ_YsWVHYoo2R_-6c' +
+  '.NpbseF3iOk9KFwB4dFvkGQ' +
+  '.wvKylM7Y1PKgGiUP1pozltCEG8uq6YnBELeT5fBBKEJ4BU5xoz1goVzczq4s_PlB-mlRAnIwHMhajtO7F-ZZnQ' +
+  '.LpMKJIPctyKLzoo2P7FIEg';
+
+// Plaintext that was encrypted to produce noZipToken.
+// protected: ['enc', 'alg', 'kid']
+export const noZipPlaintext = '{"test":"node-jose-compat","zip":false,"kid":"KIBANA"}';
+
+// node-jose compact JWE without zip.
+// Header (decoded): { enc: 'A128CBC-HS256', alg: 'RSA-OAEP', kid: 'KIBANA' }
+export const noZipToken =
+  'eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJLSUJBTkEifQ' +
+  '.AbRdvf7LXF39xwsg4z-dfGysjk3iPXJhEDOWdj0zu1LSSy1xbYxqe_2AzRAL1DkB41-0uC16IRPVbRyaUnGdVpK' +
+  'DNcp-E1xQqfAa1a3rajtX8TtzcUq26rtOtbp1VAiSlzT6qCGcYEJmu4_3a7glylVaWzlP1m5b9-PRoeCGNsA' +
+  '.wkPtsnbazNLShZaA-ZpRVQ' +
+  '.KpwJduhqQ4GI1-IUyIPMAGvMpQPFKI1WZQd5FdlJMbmDhYdvnX1xB81e5PlHj8iHnu4StmsjNPgGcdNaUOcvIw' +
+  '.XkdafuH5ho9KmuJP2eK40A';
+
+// Plaintext (before AES+JWE) for the full packed-body vector below.
+export const packedBodyPlaintext = '{"test":"packed-body-compat","source":"node-jose"}';
+
+// Full request-crypto wire format: packBody(encryptedAESKey, encryptedPayload).
+// Built with: node-jose JWE (zip:true) wrapping a random 32-byte AES key,
+//             @elastic/node-crypto AES encrypting packedBodyPlaintext,
+//             node-jose util.base64url.encode of the JSON envelope.
+// Decryptable end-to-end by createRequestDecryptor(privateJWKS).
+export const packedBody =
+  'eyJlbmNyeXB0ZWRBRVNLZXkiOiJleUo2YVhBaU9pSkVSVVlpTENKbGJtTWlPaUpCTVRJNFEwSkRMVWhUTWpVMkl' +
+  'pd2lZV3huSWpvaVVsTkJMVTlCUlZBaUxDSnJhV1FpT2lKTFNVSkJUa0VpZlEuT2wyYXlpNU9md2tqQ21EU0xXbH' +
+  'R2U3ZmLXVvNGlPcWc5TUFCM0tVakNUVkxXOW8wODJoUllHQ19rWlY3Z0NzUDBVVUJNZXJrTlZJT2o2Y0QwLW1E' +
+  'OEg1eXc3X1hiaDYxWVpKZHNmQmdtMXBtdzdsM2FHQnJxMm5ucmc0VzZZekZuODRhTUk1R0s2RGdiUkdRZTIwcFN' +
+  'aNzlTbXp6ZEJVVnVWMnlER00yUTdRLmF6UTNxUnNaUG50ZTVxdTlkS1Roc1EubThrTVVUZkZOUWlFTkcxaklhVl' +
+  'RHR3VpOHBNSEJCQmcyQ1hralc3anE1MWJyU2cwLUpiWHdKazRCUVBKTWFoVC5KWDBld0d0MGdJaldEUkhZUzFyVj' +
+  'FBIiwiZW5jcnlwdGVkUGF5bG9hZCI6ImRwSWQyc1VTWFdNekp4UmNRSHBRcWcwOFJ0b1pzL2FSYk1CQktTTGgv' +
+  'UXN2OWZhNTV1cG5NR2NmY2ZveFVQSXkrYlp4OXZrSG1TYTdCaE03L0RwejdGRG13K3BVUjd6K2RkcDFsclc3bnp' +
+  'ENDhMTW8wYVM0Qk9EdjArVHE5ZFIvVGJXYVRWbjh5VkNxcGdmOHYraUhXclRnRERad1ZTZUwxOWFGQmw4bTZWS2' +
+  'tzbjdndU1KUHlOQlFXYlNKeGc9PSJ9';
+
+// Sentinel inputs and output for packBody encoding test.
+// packedBodySentinel === Buffer.from(JSON.stringify({
+//   encryptedAESKey: packedBodySentinelAESKey,
+//   encryptedPayload: packedBodySentinelPayload,
+// }), 'utf8').toString('base64url')
+// This value is deterministic (no crypto) and verifies Buffer.toString('base64url')
+// is byte-identical to node-jose's util.base64url.encode.
+export const packedBodySentinelAESKey = 'sentinel-aes-key-for-pack-test';
+export const packedBodySentinelPayload = 'sentinel-encrypted-payload-value';
+export const packedBodySentinel =
+  'eyJlbmNyeXB0ZWRBRVNLZXkiOiJzZW50aW5lbC1hZXMta2V5LWZvci1wYWNrLXRlc3QiLCJlbmNyeXB0ZWRQYXlsb2FkIjoic2VudGluZWwtZW5jcnlwdGVkLXBheWxvYWQtdmFsdWUifQ';
+
+// JWKMetadata shape node-jose returns from decrypt result.
+// Use to assert our metadata() snapshot matches exactly.
+export const zipKeyMeta = {
+  kty: 'RSA',
+  kid: 'KIBANA',
+  use: 'enc',
+  alg: 'RSA-OAEP',
+  length: 1024,
+};

--- a/test/jwk.spec.ts
+++ b/test/jwk.spec.ts
@@ -1,36 +1,28 @@
-import * as jose from 'node-jose';
 import { createJWKManager } from '../src/jwk';
 
 import { privateJWKS } from './fixture/private_jwks';
 import { publicJWKS } from './fixture/public_jwks';
 
-const mockJWK = Object.assign({}, jose.JWK, {
-  createKey(type: any, modulus: any, config: any) {
-    // override modulus bit size for faster tests.
-    return jose.JWK.createKey(type, 1024, config);
-  },
-});
-
 describe('JSON Web Keys Manager', () => {
   describe('JWKS', () => {
     it('creates an empty key set', async () => {
-      const manager = await createJWKManager(undefined, mockJWK);
+      const manager = await createJWKManager(undefined);
       const jwks = manager.getPrivateJWKS();
 
       expect(jwks).to.eql({ keys: [] });
     });
     it('prepopulates public key sets', async () => {
-      const manager = await createJWKManager(publicJWKS, mockJWK);
+      const manager = await createJWKManager(publicJWKS);
       expect(manager.getPrivateJWKS()).to.eql(publicJWKS);
       expect(manager.getPublicJWKS()).to.eql(publicJWKS);
     });
     it('prepopulates private key sets', async () => {
-      const manager = await createJWKManager(privateJWKS, mockJWK);
+      const manager = await createJWKManager(privateJWKS);
       expect(manager.getPrivateJWKS()).to.eql(privateJWKS);
       expect(manager.getPublicJWKS()).to.eql(publicJWKS);
     });
     it('adds a new key to the set', async () => {
-      const manager = await createJWKManager(undefined, mockJWK);
+      const manager = await createJWKManager(undefined);
       await manager.addKey('KIBANA_2');
       const { keys } = manager.getPrivateJWKS();
       expect(keys).to.have.length(1);
@@ -43,12 +35,12 @@ describe('JSON Web Keys Manager', () => {
     let encryptedMessage: string;
 
     it('encrypts Buffer input with public key set', async () => {
-      const manager = await createJWKManager(publicJWKS, mockJWK);
+      const manager = await createJWKManager(publicJWKS);
       encryptedMessage = await manager.encrypt('KIBANA', inputBuffer);
       expect(encryptedMessage).to.be.a('string');
     });
     it('cannot decrypt messages using public key set', async () => {
-      const manager = await createJWKManager(publicJWKS, mockJWK);
+      const manager = await createJWKManager(publicJWKS);
       let errorMessage = '';
       try {
         await manager.decrypt(encryptedMessage);
@@ -58,13 +50,13 @@ describe('JSON Web Keys Manager', () => {
       expect(errorMessage).to.equal('Error: no key found');
     });
     it('decrypts messages using private key set', async () => {
-      const manager = await createJWKManager(privateJWKS, mockJWK);
+      const manager = await createJWKManager(privateJWKS);
       const { payload: messageBuffer } = await manager.decrypt(encryptedMessage);
       const messageObject = messageBuffer.toString();
       expect(messageObject).to.equal(originalInput);
     });
     it('returns JWKDecryptResult contract', async () => {
-      const manager = await createJWKManager(privateJWKS, mockJWK);
+      const manager = await createJWKManager(privateJWKS);
       const jwkDecryptResult = await manager.decrypt(encryptedMessage);
       expect(jwkDecryptResult.header).to.eql({
         zip: 'DEF',
@@ -75,6 +67,7 @@ describe('JSON Web Keys Manager', () => {
       expect(jwkDecryptResult.protected).to.eql(['zip', 'enc', 'alg', 'kid']);
       expect(Buffer.isBuffer(jwkDecryptResult.plaintext)).to.equal(true);
       expect(Buffer.isBuffer(jwkDecryptResult.payload)).to.equal(true);
+      expect(jwkDecryptResult.payload).to.equal(jwkDecryptResult.plaintext);
       const { kty, kid, use, alg } = manager.getPublicJWK('KIBANA');
       expect(jwkDecryptResult.key).to.eql({
         kty,
@@ -82,14 +75,13 @@ describe('JSON Web Keys Manager', () => {
         use,
         alg,
         length: 1024,
-        keystore: {},
       });
     });
     it('cannot decrypt messages not encrypted with matching keys', async () => {
-      const unworldlyManager = await createJWKManager(undefined, mockJWK);
+      const unworldlyManager = await createJWKManager(undefined);
       await unworldlyManager.addKey('KIBANA_7.0');
       const undecryptableMessage = await unworldlyManager.encrypt('KIBANA_7.0', inputBuffer);
-      const manager = await createJWKManager(privateJWKS, mockJWK);
+      const manager = await createJWKManager(privateJWKS);
 
       let errorMessage = '';
       try {

--- a/test/jwks.spec.ts
+++ b/test/jwks.spec.ts
@@ -1,0 +1,370 @@
+import { createJWKS, createJWKSManager, JWKSManager } from '../src/jwks';
+import { KeyStore } from '../src/keystore';
+
+import { privateComponents, publicComponents } from './helpers';
+
+import { privateJWKS } from './fixture/private_jwks';
+import { publicJWKS } from './fixture/public_jwks';
+
+// RFC 7638 thumbprint for the KIBANA public key — verified at runtime
+const KIBANA_THUMBPRINT = 'h5FaWD7kjAc8X7omy0-7yP3ieAcOXPHuaI8SOgcRXUw';
+
+describe('JWKSManager', () => {
+  describe('getPublicJWK', () => {
+    it('returns public JWK by kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwk = manager.getPublicJWK('KIBANA');
+      expect(jwk).to.not.equal(null);
+      expect(Object.keys(jwk)).to.eql(publicComponents);
+    });
+
+    it('returns first key when no kid given', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwk = manager.getPublicJWK();
+      expect(jwk).to.not.equal(null);
+      expect(jwk.kid).to.equal('KIBANA');
+    });
+
+    it('returns null for unknown kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      expect(manager.getPublicJWK('MISSING')).to.equal(null);
+    });
+
+    it('returns a fresh copy each call (not a shared reference)', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const a = manager.getPublicJWK('KIBANA');
+      const b = manager.getPublicJWK('KIBANA');
+      expect(a).to.not.equal(b);
+      expect(a).to.eql(b);
+    });
+
+    it('never exposes private members', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwk = manager.getPublicJWK('KIBANA') as any;
+      expect(jwk.d).to.equal(undefined);
+    });
+  });
+
+  describe('getPrivateJWK', () => {
+    it('returns private JWK by kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwk = manager.getPrivateJWK('KIBANA');
+      expect(jwk).to.not.equal(null);
+      expect(Object.keys(jwk)).to.eql(privateComponents);
+    });
+
+    it('returns first key with no argument', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwk = manager.getPrivateJWK();
+      expect(jwk).to.not.equal(null);
+      expect(jwk.kid).to.equal('KIBANA');
+    });
+
+    it('returns null for unknown kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      expect(manager.getPrivateJWK('MISSING')).to.equal(null);
+    });
+
+    it('returns null on public-only store', async () => {
+      const manager = await createJWKSManager(publicJWKS);
+      expect(manager.getPrivateJWK('KIBANA')).to.equal(null);
+    });
+  });
+
+  describe('getPublicJWKS', () => {
+    it('returns only public members', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwks = manager.getPublicJWKS();
+      expect(jwks.keys).to.have.length(1);
+      expect(Object.keys(jwks.keys[0])).to.eql(publicComponents);
+    });
+
+    it('never exposes private members', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const jwks = manager.getPublicJWKS();
+      expect((jwks.keys[0] as any).d).to.equal(undefined);
+    });
+  });
+
+  describe('insertKey / addKey', () => {
+    it('insertKey accepts a JWK object', async () => {
+      const manager = await createJWKSManager();
+      await manager.insertKey(privateJWKS.keys[0]);
+      expect(manager.store.all()).to.have.length(1);
+    });
+
+    it('insertKey accepts a JSON string', async () => {
+      const manager = await createJWKSManager();
+      await manager.insertKey(JSON.stringify(privateJWKS.keys[0]));
+      expect(manager.store.all()).to.have.length(1);
+    });
+
+    it('insertKey accepts a Buffer', async () => {
+      const manager = await createJWKSManager();
+      await manager.insertKey(Buffer.from(JSON.stringify(privateJWKS.keys[0]), 'utf8'));
+      expect(manager.store.all()).to.have.length(1);
+    });
+
+    it('insertKey copies input (caller mutation does not affect store)', async () => {
+      const manager = await createJWKSManager();
+      const jwk = Object.assign({}, privateJWKS.keys[0]);
+      await manager.insertKey(jwk);
+      (jwk as any).kid = 'TAMPERED';
+      expect(manager.getPublicJWK('KIBANA')).to.not.equal(null);
+    });
+
+    it('insertKey rejects non-RSA key', async () => {
+      const manager = await createJWKSManager();
+      let errorMessage = '';
+      try {
+        await manager.insertKey({ kty: 'EC' } as any);
+      } catch (err) {
+        errorMessage = err.toString();
+      }
+      expect(errorMessage).to.include('unsupported key type');
+    });
+
+    it('insertKey rejects malformed JSON string', async () => {
+      const manager = await createJWKSManager();
+      let errorMessage = '';
+      try {
+        await manager.insertKey('not-json');
+      } catch (err) {
+        errorMessage = err.toString();
+      }
+      expect(errorMessage).to.be.a('string');
+    });
+
+    it('addKey generates a key with the given kid', async () => {
+      const manager = await createJWKSManager();
+      await manager.addKey('MY_KEY', 1024, 'enc');
+      const jwk = manager.getPublicJWK('MY_KEY');
+      expect(jwk).to.not.equal(null);
+      expect(jwk.kid).to.equal('MY_KEY');
+    });
+
+    it('addKey with no kid generates a uuid kid', async () => {
+      const manager = await createJWKSManager();
+      await manager.addKey(undefined, 1024, 'enc');
+      const keys = manager.store.all();
+      expect(keys).to.have.length(1);
+      // uuid format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      expect(keys[0].kid).to.match(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      );
+    });
+
+    it('addKey honours requested modulus', async () => {
+      const manager = await createJWKSManager();
+      await manager.addKey('K1024', 1024, 'enc');
+      const key = manager.store.get('K1024');
+      expect(key.length).to.equal(1024);
+    });
+  });
+
+  describe('removeKey', () => {
+    it('removes a key by kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      manager.removeKey(privateJWKS.keys[0]);
+      expect(manager.store.all()).to.have.length(0);
+    });
+
+    it('is a no-op for unknown kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      manager.removeKey({ kid: 'MISSING' } as any);
+      expect(manager.store.all()).to.have.length(1);
+    });
+
+    it('removes all entries with the same kid', async () => {
+      const manager = await createJWKSManager();
+      await manager.insertKey(privateJWKS.keys[0]);
+      await manager.insertKey(privateJWKS.keys[0]);
+      expect(manager.store.all()).to.have.length(2);
+      manager.removeKey(privateJWKS.keys[0]);
+      expect(manager.store.all()).to.have.length(0);
+    });
+
+    it('leaves other keys intact', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      await manager.addKey('OTHER', 1024, 'enc');
+      manager.removeKey(privateJWKS.keys[0]);
+      expect(manager.store.all()).to.have.length(1);
+      expect(manager.store.get('OTHER')).to.not.equal(null);
+    });
+  });
+
+  describe('getKey', () => {
+    it('returns first key with no argument', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const key = (manager as any).getKey();
+      expect(key).to.not.equal(null);
+      expect(key.kid).to.equal('KIBANA');
+    });
+
+    it('returns null for unknown kid', async () => {
+      const manager = await createJWKSManager(privateJWKS);
+      const key = (manager as any).getKey('MISSING');
+      expect(key).to.equal(null);
+    });
+  });
+});
+
+describe('KeyStore', () => {
+  describe('get with filter object', () => {
+    it('matches by use', async () => {
+      const store = await createJWKS(privateJWKS);
+      const key = store.get({ use: 'enc' });
+      expect(key).to.not.equal(null);
+      expect(key.use).to.equal('enc');
+    });
+
+    it('returns null when filter has no match', async () => {
+      const store = await createJWKS(privateJWKS);
+      expect(store.get({ use: 'sig' })).to.equal(null);
+    });
+
+    it('skips alg check when key has no alg', async () => {
+      const store = new KeyStore();
+      const noAlg = Object.assign({}, privateJWKS.keys[0]);
+      delete (noAlg as any).alg;
+      await store.add(noAlg);
+      // filter alg 'RSA-OAEP' should still match (falsy-skip)
+      const key = store.get({ alg: 'RSA-OAEP' });
+      expect(key).to.not.equal(null);
+    });
+  });
+
+  describe('all', () => {
+    it('returns keys in insertion order', async () => {
+      const store = new KeyStore();
+      await store.add(privateJWKS.keys[0]);
+      await store.add(publicJWKS.keys[0]);
+      const keys = store.all();
+      expect(keys[0].kid).to.equal('KIBANA');
+      expect(keys[1].kid).to.equal('KIBANA');
+    });
+
+    it('returns empty array when store is empty', () => {
+      const store = new KeyStore();
+      expect(store.all()).to.eql([]);
+    });
+  });
+
+  describe('toJSON member order', () => {
+    it('public toJSON emits kty,kid,use,alg,e,n', async () => {
+      const store = await createJWKS(privateJWKS);
+      const jwks = store.toJSON();
+      expect(Object.keys(jwks.keys[0])).to.eql(publicComponents);
+    });
+
+    it('private toJSON emits kty,kid,use,alg,e,n,d,p,q,dp,dq,qi', async () => {
+      const store = await createJWKS(privateJWKS);
+      const jwks = store.toJSON(true);
+      expect(Object.keys(jwks.keys[0])).to.eql(privateComponents);
+    });
+
+    it('omits use when absent', async () => {
+      const store = new KeyStore();
+      const noUse = Object.assign({}, privateJWKS.keys[0]);
+      delete (noUse as any).use;
+      await store.add(noUse);
+      const jwk = store.toJSON().keys[0] as any;
+      expect(jwk.use).to.equal(undefined);
+    });
+
+    it('omits alg when absent', async () => {
+      const store = new KeyStore();
+      const noAlg = Object.assign({}, privateJWKS.keys[0]);
+      delete (noAlg as any).alg;
+      await store.add(noAlg);
+      const jwk = store.toJSON().keys[0] as any;
+      expect(jwk.alg).to.equal(undefined);
+    });
+  });
+
+  describe('kid assignment', () => {
+    it('uses kid from JWK when present', async () => {
+      const store = await createJWKS(privateJWKS);
+      expect(store.get().kid).to.equal('KIBANA');
+    });
+
+    it('falls back to RFC 7638 thumbprint when kid absent', async () => {
+      const store = new KeyStore();
+      const noKid = Object.assign({}, privateJWKS.keys[0]);
+      delete (noKid as any).kid;
+      await store.add(noKid);
+      expect(store.get().kid).to.equal(KIBANA_THUMBPRINT);
+    });
+  });
+
+  describe('length field', () => {
+    it('reports 1024 for 1024-bit KIBANA key', async () => {
+      const store = await createJWKS(privateJWKS);
+      expect(store.get().length).to.equal(1024);
+    });
+  });
+});
+
+describe('createJWKS', () => {
+  it('creates empty store when called with no argument', async () => {
+    const store = await createJWKS();
+    expect(store.all()).to.eql([]);
+  });
+
+  it('loads keys from JWKS object', async () => {
+    const store = await createJWKS(privateJWKS);
+    expect(store.all()).to.have.length(1);
+  });
+
+  it('loads keys from JSON string', async () => {
+    const store = await createJWKS(JSON.stringify(privateJWKS));
+    expect(store.all()).to.have.length(1);
+  });
+
+  it('loads keys from Buffer', async () => {
+    const store = await createJWKS(Buffer.from(JSON.stringify(privateJWKS), 'utf8'));
+    expect(store.all()).to.have.length(1);
+  });
+
+  it('throws TypeError for non-JWKS object', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKS({ notKeys: [] } as any);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('TypeError');
+  });
+
+  it('throws TypeError for invalid JSON string', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKS('not-json' as any);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('TypeError');
+  });
+});
+
+describe('createJWKSManager', () => {
+  it('creates a JWKSManager', async () => {
+    const manager = await createJWKSManager(privateJWKS);
+    expect(manager).to.be.instanceOf(JWKSManager);
+  });
+
+  it('creates an empty manager when called with no argument', async () => {
+    const manager = await createJWKSManager();
+    expect(manager.store.all()).to.eql([]);
+  });
+
+  it('throws on invalid maxDecompressedSize', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKSManager(undefined, { maxDecompressedSize: 0 });
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('maxDecompressedSize');
+  });
+});

--- a/test/request.spec.ts
+++ b/test/request.spec.ts
@@ -1,3 +1,4 @@
+import { createJWKSManager } from '../src/jwks';
 import { createRequestDecryptor, createRequestEncryptor } from '../src/request';
 
 import { privateJWKS } from './fixture/private_jwks';
@@ -81,6 +82,40 @@ describe('Request Crypto', () => {
         errorMessage = err.toString();
       }
       expect(errorMessage).to.equal('Error: no key found');
+    });
+  });
+
+  describe('getPublicComponent', () => {
+    it('returns public JWK for known kid', async () => {
+      const decryptor = await createRequestDecryptor(privateJWKS);
+      const jwk = decryptor.getPublicComponent('KIBANA');
+      expect(jwk).to.not.equal(null);
+      expect(Object.keys(jwk)).to.eql(publicComponents);
+    });
+
+    it('returns null for unknown kid', async () => {
+      const decryptor = await createRequestDecryptor(privateJWKS);
+      expect(decryptor.getPublicComponent('MISSING')).to.equal(null);
+    });
+
+    it('never exposes private members', async () => {
+      const decryptor = await createRequestDecryptor(privateJWKS);
+      const jwk = decryptor.getPublicComponent('KIBANA') as any;
+      expect(jwk.d).to.equal(undefined);
+    });
+  });
+
+  describe('2048-bit end-to-end round-trip', () => {
+    it('encrypts and decrypts with a 2048-bit key', async () => {
+      const manager = await createJWKSManager();
+      await manager.addKey('K2048', 2048, 'enc');
+      const pub = manager.getPublicJWKS();
+      const priv = manager.getPrivateJWKS();
+      const encryptor = await createRequestEncryptor(pub);
+      const decryptor = await createRequestDecryptor(priv);
+      const encrypted = await encryptor.encrypt('K2048', smallPayload);
+      const decrypted = await decryptor.decrypt(encrypted);
+      expect(decrypted).to.eql(smallPayload);
     });
   });
 });

--- a/test/security.spec.ts
+++ b/test/security.spec.ts
@@ -1,0 +1,417 @@
+import {
+  CONTENT_ALGORITHM,
+  decryptContent,
+  encryptCompact,
+  MAX_DECOMPRESSED_SIZE,
+  parseCompact,
+  ZIP_DEFLATE,
+} from '../src/jwe';
+import { createJWKSManager } from '../src/jwks';
+import { createRequestDecryptor, packBody } from '../src/request';
+
+import { privateJWKS } from './fixture/private_jwks';
+import { publicJWKS } from './fixture/public_jwks';
+
+// RFC 7518 Appendix B.1 — AES_128_CBC_HMAC_SHA_256 fixed test vector
+// https://www.rfc-editor.org/rfc/rfc7518#appendix-B.1
+// All values verified against the RFC hex dump (fetched 2026-08-04).
+const B1_CEK = Buffer.from(
+  '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+  'hex'
+);
+const B1_IV = Buffer.from('1af38c2dc2b96ffdd86694092341bc04', 'hex');
+// RFC 7518 B.1 plaintext (128 bytes) — exactly fills 8 CBC blocks; PKCS7 adds a 9th.
+// "A cipher system must not be required to be secret, and it must be able to
+//  fall into the hands of the enemy without inconvenience"
+const B1_PLAINTEXT = Buffer.from(
+  'A cipher system must not be required to be secret, ' +
+    'and it must be able to fall into the hands of the enemy without inconvenience',
+  'ascii'
+);
+// RFC 7518 B.1 AAD (42 bytes) — "The second principle of Auguste Kerckhoffs"
+// AL = 42 * 8 = 336 = 0x150 (verified: RFC shows AL = 00 00 00 00 00 00 01 50)
+const B1_AAD = Buffer.from('The second principle of Auguste Kerckhoffs', 'ascii');
+// 144 bytes: AES-128-CBC(ENC_KEY, IV, PKCS7-padded-plaintext); 9 × 16-byte rows from RFC B.1 hex.
+const B1_CIPHERTEXT = Buffer.from(
+  'c80edfa32ddf39d5ef00c0b468834279a2e46a1b8049f792f76bfe54b903a9c9' +
+    'a94ac9b47ad2655c5f10f9aef71427e2fc6f9b3f399a221489f16362c7032336' +
+    '09d45ac69864e3321cf82935ac4096c86e133314c54019e8ca7980dfa4b9cf1b' +
+    '384c486f3a54c51078158ee5d79de59fbd34d848b3d69550a67646344427ade5' +
+    '4b8851ffb598f7f80074b9473c82e2db',
+  'hex'
+);
+const B1_TAG = Buffer.from('652c3fa36b0a7c5b3219fab3a30bc1c4', 'hex');
+
+// RFC 7516 Appendix A.2 — content-layer vector (alg=RSA1_5, but CEK/IV/ciphertext/tag are valid)
+// https://www.rfc-editor.org/rfc/rfc7516#appendix-A.2
+// CEK from A.2.1, IV/ciphertext/tag taken from the compact JWE in A.2.5.
+const A2_CEK = Buffer.from(
+  '04d31fc5549dfcfe0b649dfa3faa6ace6b7cd42d6f6b09dbc8b100f08f9c2ccf',
+  'hex'
+);
+const A2_IV = Buffer.from('AxY8DCtDaGlsbGljb3RoZQ', 'base64url');
+const A2_AAD = Buffer.from('eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0', 'ascii');
+const A2_CIPHERTEXT = Buffer.from('KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY', 'base64url');
+const A2_TAG = Buffer.from('9hH0vgRfYgPnAHOd8stkvw', 'base64url');
+const A2_PLAINTEXT = Buffer.from('Live long and prosper.', 'ascii');
+
+describe('RFC spec vectors', () => {
+  describe('RFC 7518 Appendix B.1 — AES_128_CBC_HMAC_SHA_256', () => {
+    it('decryptContent reproduces the spec plaintext', () => {
+      const parsed = {
+        protectedHeader: { enc: CONTENT_ALGORITHM },
+        protectedFields: ['enc'],
+        aad: B1_AAD,
+        encryptedKey: Buffer.alloc(0),
+        iv: B1_IV,
+        ciphertext: B1_CIPHERTEXT,
+        tag: B1_TAG,
+      };
+      const pt = decryptContent(parsed as any, B1_CEK);
+      expect(pt).to.eql(B1_PLAINTEXT);
+    });
+  });
+
+  describe('RFC 7516 Appendix A.2 — content-layer vector', () => {
+    it('decryptContent authenticates and decrypts A.2 ciphertext', () => {
+      const parsed = {
+        protectedHeader: { enc: CONTENT_ALGORITHM },
+        protectedFields: ['enc'],
+        aad: A2_AAD,
+        encryptedKey: Buffer.alloc(0),
+        iv: A2_IV,
+        ciphertext: A2_CIPHERTEXT,
+        tag: A2_TAG,
+      };
+      const pt = decryptContent(parsed as any, A2_CEK);
+      expect(pt).to.eql(A2_PLAINTEXT);
+    });
+  });
+});
+
+describe('JWE tamper detection', () => {
+  let validToken: string;
+  let manager: any;
+
+  before(async () => {
+    manager = await createJWKSManager(privateJWKS);
+    validToken = await manager.encrypt('KIBANA', Buffer.from('test-payload', 'utf8'));
+  });
+
+  function tamperByte(token: string, segIndex: number): string {
+    const segs = token.split('.');
+    const buf = Buffer.from(segs[segIndex], 'base64url');
+    buf[0] = (buf[0] + 1) % 256;
+    segs[segIndex] = buf.toString('base64url');
+    return segs.join('.');
+  }
+
+  it('rejects tampered authentication tag', async () => {
+    let errorMessage = '';
+    try {
+      await manager.decrypt(tamperByte(validToken, 4));
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('decryption failed');
+  });
+
+  it('rejects tampered ciphertext — error is "decryption failed", not a padding oracle', async () => {
+    let errorMessage = '';
+    try {
+      await manager.decrypt(tamperByte(validToken, 3));
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    // MAC-before-decrypt: CBC padding error must never surface
+    expect(errorMessage).to.include('decryption failed');
+    expect(errorMessage).to.not.include('bad decrypt');
+  });
+
+  it('rejects tampered protected header (AAD covers it)', async () => {
+    const segs = validToken.split('.');
+    segs[0] = segs[0] + 'X';
+    let errorMessage = '';
+    try {
+      await manager.decrypt(segs.join('.'));
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage.length).to.be.greaterThan(0);
+  });
+});
+
+describe('JWE parsing validation', () => {
+  let manager: any;
+  before(async () => {
+    manager = await createJWKSManager(privateJWKS);
+  });
+
+  it('rejects 4-segment compact', async () => {
+    let errorMessage = '';
+    try {
+      await manager.decrypt('a.b.c.d');
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('5 segments');
+  });
+
+  it('rejects 6-segment compact', async () => {
+    let errorMessage = '';
+    try {
+      await manager.decrypt('a.b.c.d.e.f');
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('5 segments');
+  });
+
+  it('rejects non-JSON header', async () => {
+    const bad = Buffer.from('not-json').toString('base64url') + '.b.c.d.e';
+    let errorMessage = '';
+    try {
+      await manager.decrypt(bad);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage.length).to.be.greaterThan(0);
+  });
+
+  it('rejects header that is a JSON string (not object)', async () => {
+    const bad = Buffer.from('"string"').toString('base64url') + '.b.c.d.e';
+    let errorMessage = '';
+    try {
+      await manager.decrypt(bad);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('object');
+  });
+});
+
+describe('key-not-found scenarios', () => {
+  let manager: any;
+  let token: string;
+
+  before(async () => {
+    manager = await createJWKSManager(privateJWKS);
+    token = await manager.encrypt('KIBANA', Buffer.from('hello', 'utf8'));
+  });
+
+  function replaceHeader(t: string, header: object): string {
+    const segs = t.split('.');
+    segs[0] = Buffer.from(JSON.stringify(header)).toString('base64url');
+    return segs.join('.');
+  }
+
+  it('RSA1_5 alg yields no key found', async () => {
+    const t = replaceHeader(token, { enc: CONTENT_ALGORITHM, alg: 'RSA1_5', kid: 'KIBANA' });
+    let errorMessage = '';
+    try {
+      await manager.decrypt(t);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.equal('Error: no key found');
+  });
+
+  it('dir alg yields no key found', async () => {
+    const t = replaceHeader(token, { enc: CONTENT_ALGORITHM, alg: 'dir', kid: 'KIBANA' });
+    let errorMessage = '';
+    try {
+      await manager.decrypt(t);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.equal('Error: no key found');
+  });
+
+  it('unknown kid yields no key found', async () => {
+    const t = replaceHeader(token, { enc: CONTENT_ALGORITHM, alg: 'RSA-OAEP', kid: 'UNKNOWN' });
+    let errorMessage = '';
+    try {
+      await manager.decrypt(t);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.equal('Error: no key found');
+  });
+
+  it('public-only store yields no key found', async () => {
+    const pubManager = await createJWKSManager(publicJWKS);
+    let errorMessage = '';
+    try {
+      await pubManager.decrypt(token);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.equal('Error: no key found');
+  });
+});
+
+describe('unsupported algorithms', () => {
+  it('unsupported enc (A256GCM) throws at decryptContent', () => {
+    const parsed = {
+      protectedHeader: { enc: 'A256GCM' },
+      protectedFields: ['enc'],
+      aad: Buffer.alloc(0),
+      encryptedKey: Buffer.alloc(0),
+      iv: Buffer.alloc(16),
+      ciphertext: Buffer.alloc(16),
+      tag: Buffer.alloc(16),
+    };
+    let errorMessage = '';
+    try {
+      decryptContent(parsed as any, Buffer.alloc(32));
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('unsupported "enc"');
+  });
+
+  it('unsupported zip (GZ) throws after successful MAC', async () => {
+    const manager = await createJWKSManager(privateJWKS);
+    const key = manager.store.get('KIBANA');
+    // encryptCompact with zip: 'GZ' stores uncompressed content but labels it 'GZ' — MAC is valid
+    const gzToken = encryptCompact(
+      key.publicKey,
+      { zip: 'GZ', enc: CONTENT_ALGORITHM, alg: 'RSA-OAEP', kid: 'KIBANA' },
+      Buffer.from('hello', 'utf8')
+    );
+    let errorMessage = '';
+    try {
+      await manager.decrypt(gzToken);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('unsupported "zip"');
+  });
+});
+
+describe('decompression bomb protection', () => {
+  let manager: any;
+  let bombToken: string;
+
+  before(async () => {
+    manager = await createJWKSManager(privateJWKS);
+    // Payload just above the default limit; deflateRaw compresses it well but inflate will exceed cap
+    const bigPayload = Buffer.alloc(MAX_DECOMPRESSED_SIZE + 1, 0x41);
+    bombToken = await manager.encrypt('KIBANA', bigPayload);
+  });
+
+  it('rejects payload exceeding MAX_DECOMPRESSED_SIZE by default', async () => {
+    let errorMessage = '';
+    try {
+      await manager.decrypt(bombToken);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include(String(MAX_DECOMPRESSED_SIZE));
+  });
+
+  it('succeeds when limit is raised above payload size', async () => {
+    const raised = await createJWKSManager(privateJWKS, {
+      maxDecompressedSize: MAX_DECOMPRESSED_SIZE + 100,
+    });
+    const result = await raised.decrypt(bombToken);
+    expect(Buffer.isBuffer(result.plaintext)).to.equal(true);
+    expect(result.plaintext.length).to.equal(MAX_DECOMPRESSED_SIZE + 1);
+  });
+
+  it('rejects at a limit just below payload size', async () => {
+    const tight = await createJWKSManager(privateJWKS, {
+      maxDecompressedSize: MAX_DECOMPRESSED_SIZE,
+    });
+    let errorMessage = '';
+    try {
+      await tight.decrypt(bombToken);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include(String(MAX_DECOMPRESSED_SIZE));
+  });
+
+  it('error message names the effective limit when raised', async () => {
+    // Build a token slightly above the raised limit
+    const raisedLimit = 50000;
+    const raised = await createJWKSManager(privateJWKS, { maxDecompressedSize: raisedLimit });
+    const bigPayload = Buffer.alloc(raisedLimit + 1, 0x42);
+    const overToken = await raised.encrypt('KIBANA', bigPayload);
+    let errorMessage = '';
+    try {
+      await raised.decrypt(overToken);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include(String(raisedLimit));
+  });
+
+  it('option is reachable via createRequestDecryptor', async () => {
+    const raised = await createRequestDecryptor(privateJWKS, {
+      maxDecompressedSize: MAX_DECOMPRESSED_SIZE + 100,
+    });
+    // Pack bombToken as the AES key portion; the decrypt will fail at AES level (not JWE level)
+    const packed = packBody(bombToken, 'dummy');
+    let errorMessage = '';
+    try {
+      await raised.decrypt(packed);
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    // Should NOT fail with 'decompressed payload exceeds limit'
+    expect(errorMessage).to.not.include('decompressed payload exceeds limit');
+  });
+
+  it('constructor throws on maxDecompressedSize: 0', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKSManager(undefined, { maxDecompressedSize: 0 });
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('maxDecompressedSize');
+  });
+
+  it('constructor throws on negative maxDecompressedSize', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKSManager(undefined, { maxDecompressedSize: -1 });
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('maxDecompressedSize');
+  });
+
+  it('constructor throws on NaN', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKSManager(undefined, { maxDecompressedSize: NaN });
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('maxDecompressedSize');
+  });
+
+  it('constructor throws on Infinity', async () => {
+    let errorMessage = '';
+    try {
+      await createJWKSManager(undefined, { maxDecompressedSize: Infinity });
+    } catch (err) {
+      errorMessage = err.toString();
+    }
+    expect(errorMessage).to.include('maxDecompressedSize');
+  });
+});
+
+describe('decrypt result contains no private material', () => {
+  it('result.key has no private components', async () => {
+    const manager = await createJWKSManager(privateJWKS);
+    const token = await manager.encrypt('KIBANA', Buffer.from('hello', 'utf8'));
+    const result = await manager.decrypt(token);
+    const keyKeys = Object.keys(result.key);
+    expect(keyKeys).to.not.include('d');
+    expect(keyKeys).to.not.include('p');
+    expect(keyKeys).to.not.include('q');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,20 +389,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.0.tgz#baf17ab2cca3fcce2d322ebc30454bff487efad5"
   integrity sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==
 
-"@types/node-jose@1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@types/node-jose/-/node-jose-1.1.10.tgz#1fc559b63e665f27acedbcb91601e2fee256fad0"
-  integrity sha512-7L0ucJTugW4x/sYpQ+c5IudAwr0pFuxDVnZLpHKWpff7p1lVa3wTuNvnrzFBNeLojE+UY0cVCwNGXLxXsMIrzw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*":
-  version "22.7.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
-  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
-  dependencies:
-    undici-types "~6.19.2"
-
 "@types/node@20.10.5":
   version "20.10.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.5.tgz#47ad460b514096b7ed63a1dae26fad0914ed3ab2"
@@ -513,16 +499,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
-base64url@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
-  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -563,14 +539,6 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
@@ -828,11 +796,6 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -1031,11 +994,6 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
-
-ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1258,11 +1216,6 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash@^4.17.21:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
-  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
-
 log-symbols@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
@@ -1270,11 +1223,6 @@ log-symbols@4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
-
-long@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
-  integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
 loupe@^2.3.1:
   version "2.3.4"
@@ -1370,26 +1318,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-forge@^1.2.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
-  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
-
-node-jose@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-2.2.0.tgz#b64f3225ad6bec328509a420800de597ba2bf3ed"
-  integrity sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==
-  dependencies:
-    base64url "^3.0.1"
-    buffer "^6.0.3"
-    es6-promise "^4.2.8"
-    lodash "^4.17.21"
-    long "^5.2.0"
-    node-forge "^1.2.1"
-    pako "^2.0.4"
-    process "^0.11.10"
-    uuid "^9.0.0"
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -1498,11 +1426,6 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
-pako@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
-  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
-
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -1566,11 +1489,6 @@ process-on-spawn@^1.0.0:
   integrity sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==
   dependencies:
     fromentries "^1.2.0"
-
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1905,16 +1823,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
-
-uuid@^11.1.1, uuid@^9.0.0:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
-  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uuid@^3.3.3:
   version "3.4.0"


### PR DESCRIPTION
## Drop `node-jose` — replace with `node:crypto` + `node:zlib` built-ins (3.0.0)

### The wire format does not change

Tokens produced by 2.x and 3.x are **byte-compatible in both directions**. No re-encryption, no coordinated deploy — the encrypt and decrypt sides can be upgraded independently in either order.

The cryptographic profile is identical:

| Parameter | Value |
|---|---|
| Key wrap | `RSA-OAEP` — RSAES-OAEP, SHA-1 + MGF1-SHA-1 |
| Content encryption | `A128CBC-HS256` — AES-128-CBC + HMAC-SHA-256 |
| Compression | `zip: DEF` — raw DEFLATE (RFC 1951) |
| Serialization | JWE compact, header `{zip, enc, alg, kid}` |

Only the call path changes: `code → node-jose → node:crypto → OpenSSL` becomes `code → node:crypto → OpenSSL`. Same OpenSSL primitives, same parameters, same output bytes.

### Why

`node-jose` has had no release since 2023-03-16. Keeping it meant:
- A `resolutions: { "node-jose/uuid": "^11.1.1" }` Yarn-only workaround for CVE-2026-41907 that doesn't protect npm consumers.
- The entire `node-forge` advisory stream as a transitive dependency (pure-JS crypto that never executes on Node — node-jose routes the `RSA-OAEP` + `AES-128-CBC` profile through `node:crypto` / OpenSSL anyway).
- 15 transitive packages, ~14.7 MB on disk.

Replacing with built-ins removes all of it and leaves one runtime dependency: `@elastic/node-crypto`.

### High-level APIs — no changes

- `createRequestEncryptor(publicJWKS: PublicJWKS): Promise<Encryptor>` — unchanged
- `createRequestDecryptor(privateJWKS: PrivateJWKS): Promise<Decryptor>` — unchanged
- `Encryptor` and `Decryptor` interfaces — unchanged
- `packBody` / `unpackBody` — unchanged (wire format byte-identical to node-jose output; verified with frozen vectors)
- All JWKS/JWK types (`PublicJWK`, `PrivateJWK`, `PublicJWKS`, `PrivateJWKS`, `JWKS`, etc.) — unchanged
- `RSA_ALGORITHM`, `ENC_MODULUS` constants — unchanged
- `JWKSManager` methods (`encrypt`, `decrypt`, `getPublicJWK`, `getPrivateJWK`, `insertKey`, `removeKey`, etc.) — unchanged

### Lower-level API changes

These affect direct users of `JWKSManager`, `JWKManager`, `createJWKS`, or `createJWKManager`.

#### `createJWKS` — signature changed

```ts
// Before
createJWKS(jwk: typeof jose.JWK, jwks?: JWKS): Promise<any>

// After
createJWKS(jwks?: JWKS | string | Buffer): Promise<KeyStore>
The first argument (node-jose DI injection seam) is removed. The function now also accepts a JSON string or Buffer. A non-JWKS argument throws TypeError instead of returning an empty store.

createJWKManager / createJWKSManager — second argument changed

// Before
createJWKManager(jwks?: JWKS, jwk?: typeof jose.JWK): Promise<JWKManager>

// After
createJWKManager(jwks?: JWKS, options?: JWKSManagerOptions): Promise<JWKManager>
createJWKSManager(jwks?: JWKS, options?: JWKSManagerOptions): Promise<JWKSManager>
JWKSManager — constructor changed

// Before
constructor(store: any, jwk?: typeof jose.JWK, jwe?: typeof jose.JWE)

// After
constructor(store: KeyStore, options?: JWKSManagerOptions)
store is now typed as KeyStore (was any). The node-jose injection parameters are gone.
```

#### JWKSManagerOptions — new option

```
interface JWKSManagerOptions {
  maxDecompressedSize?: number; // default: 250_000 bytes
}
```

#### Caps inflated plaintext to protect against decompression-bomb payloads.
Threaded through `createRequestDecryptor`, `createJWKManager`, and `createJWKSManager`.

#### `JWKDecryptResult.key.keystore` — removed
Was a live node-jose back-reference to the private keystore. Already excluded from the `JWKMetadata` TypeScript type, so only untyped JS could reach it. `result.key` is now a flat snapshot — metadata can be logged without leaking key material.

### New exports

- KeyStore, StoredKey — from the package root (previously internal to node-jose). `JWKSManager.store` is now typed `KeyStore` instead of `any`.
- `RSA_OAEP_256_ALGORITHM` ('RSA-OAEP-256') — keys tagged with this algorithm now encrypt and decrypt correctly with SHA-256 OAEP.
- `JWKSManagerOptions` — options bag accepted by all factory functions.

### Other behavioral changes

- `removeKey` now works. Was a silent no-op (zero test coverage). Now removes all entries with the matching kid.
- New 250 KB decompression cap (configurable via `maxDecompressedSize`). `node-jose` had no limit. The request path has ~7,800× headroom since only a 32-byte AES key goes through JWE.
- Wrong-key / same-kid unwrap now throws `decryption failed`, not `no key found`. Substitutes a random CEK on RSA failure so the error is indistinguishable from a MAC mismatch (RFC 3218 / RFC 7516 §11 defence). The three practically-asserted cases — unknown kid, public-only store, unknown `alg` — still produce `no key found` from the store lookup.
- 

### Requirements
Node.js ≥ 16. `crypto.createPublicKey({format:'jwk'})` was introduced in Node 15.12; Buffer `base64url` encoding in Node 15.7 / 14.18.